### PR TITLE
NewExpression -> MemberExpression (for unary form)

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ adapter patterns in use today.
 
     BindExpression[Yield] :
         LeftHandSideExpression[?Yield] :: NewExpression[?Yield]
-        :: NewExpression[?Yield]
+        :: MemberExpression[?Yield]
 
     CallExpression[Yield] :
         MemberExpression[?Yield] Arguments[?Yield]
@@ -148,9 +148,9 @@ adapter patterns in use today.
 ----
 
     BindExpression :
-        :: NewExpression
+        :: MemberExpression
 
-- Let _targetReference_ be the result of evaluating _NewExpression_.
+- Let _targetReference_ be the result of evaluating _MemberExpression_.
 - If Type(_targetReference_) is **Reference**, then let _baseValue_ be GetBase(_targetReference_).
 - Else let _baseValue_ be **undefined**.
 - Let _target_ be GetValue(_targetReference_).


### PR DESCRIPTION
#4: No good use case for it.

There are only two possible use cases for `::func`:

1. You want to bind the function to `undefined` so it cannot be re-bound by the caller.
  - Use `undefined::func` or `func.bind(undefined)` as it's more explicit of the intent.
2. You just want to pass the function as an argument.
  - Binding is unnecessary here. Just use `func`.

Because `::func` ~ `func.bind(undefined)`, `func()` ~ `undefined::func()`, and the above two points, there is no good use case for this.