### PR TITLE
Add accessor for `new`

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ Using method extraction to call an object method when a DOM event occurs:
 $(".some-link").on("click", ::view.reset);
 ```
 
+Using constructor binding to wrap an AJAX result
+
+```js
+request("https://example.com/ajax/users")
+.then(users => users.map(User::new))
+```
+
 ### Motivation and Overview ###
 
 With the introduction of arrow functions in ECMAScript 6, the need for explicitly
@@ -62,12 +69,25 @@ hasOwnProp.call(obj, "x");
 Promise.resolve(123).then(console.log.bind(console));
 ```
 
+Class construction is still awkward when using higher order functions as well. And
+although ES6 makes it easier to make classes, they are still awkward to use because they
+can only be called with `new`, not as a function.
+
+```js
+request("https://example.com/ajax/users")
+.then(users => users.map(user => new User(user)))
+```
+
 This proposal introduces a new operator `::` which can be used as syntactic sugar
 for these use cases.
 
-In its binary form, the `::` operator creates a bound function such that the left
-hand side of the operator is bound as the `this` variable to the target function on
-the right hand side.
+In its binary form where the right side is `new`, the `::` operator creates a bound
+function wrapping the function's [[Construct]] method (i.e. what you get when you call
+`new`).
+
+In its binary form in any other case, the `::` operator creates a bound function such
+that the left hand side of the operator is bound as the `this` variable to the target
+function on the right hand side.
 
 In its unary prefix form, the `::` operator creates a bound function such that
 the base of the supplied reference is bound as the `this` variable to the target
@@ -100,6 +120,7 @@ adapter patterns in use today.
         BindExpression[?Yield]
 
     BindExpression[Yield] :
+        LeftHandSideExpression[?Yield] :: new
         LeftHandSideExpression[?Yield] :: [lookahead ≠ new] MemberExpression[?Yield]
         :: MemberExpression[?Yield]
 
@@ -133,19 +154,28 @@ NOTE:  The last rule means that expressions such as
 
 produce early errors because of recursive application of the first rule.
 
+
+### Bound Constructor Wrapper Functions ###
+
+A bound constructor wrapper function is an anonymous built-in function that has a [[BoundTargetConstructor]] internal slot.
+
+When a bound constructor wrapper function _F_ is called with zero or more _args_, it performs the following steps:
+
+- Assert: _F_ has a [[BoundTargetConstructor]] internal slot.
+- Let _target_ be the value of _F_'s [[BoundTargetConstructor]] internal slot.
+- Assert: IsConstructor(_target_).
+- Let _args_ be a List consisting of all the arguments passed to this function.
+- Return ? Construct(_target_, _args_).
+
+
 ### Runtime Semantics ###
 
-    BindExpression :
-        LeftHandSideExpression :: [lookahead ≠ new] MemberExpression
+**InitializeBoundFunctionProperties(F, target)**
 
-- Let _baseReference_ be the result of evaluating _LeftHandSideExpression_.
-- Let _baseValue_ be ? GetValue(_baseReference_).
-- Let _targetReference_ be the result of evaluating _MemberExpression_.
-- Let _target_ be GetValue(_targetReference_).
-- If IsCallable(_target_) is `false`, throw a `TypeError` exception.
-- Let _F_ be BoundFunctionCreate(_target_, _baseValue_, ()).
-- Let _targetHasLength_ be ? HasOwnProperty(_target_, `"length"`).
-- If _targetHasLength_ is `true`,
+The abstract operation InitializeBoundFunctionProperties, where _F_ and _target_ are functions, initializes F with the correct properties from _target_. This abstract operation performs the following steps:
+
+- Let _targetHasLength_ be HasOwnProperty(_target_, `"length"`).
+- If _targetHasLength_ is `true`, then
     - Let _targetLen_ be ? Get(_target_, `"length"`).
     - If Type(_targetLen_) is not `Number`, then let _L_ be `0`.
     - Else, let _L_ be ToInteger(_targetLen_).
@@ -154,7 +184,35 @@ produce early errors because of recursive application of the first rule.
 - Let _targetName_ be ? Get(_target_, `"name"`).
 - If Type(_targetName_) is not `String`, then let _targetName_ be the empty string.
 - Let _status_ be ? SetFunctionName(_F_, _targetName_, `"bound"`).
+- Assert: _status_ is never used.
 - Return _F_.
+
+
+----
+
+    BindExpression:
+        LeftHandSideExpression :: new
+
+- Let _targetReference_ be the result of evaluating _LeftHandSideExpression_.
+- Let _target_ be GetValue(_targetReference_).
+- If IsConstructor(_target_) is `false`, throw a `TypeError` exception.
+- Let _bound_ be a new bound constructor wrapper function as defined in Bound Constructor Wrapper Functions.
+- Set the [[BoundTargetConstructor]] internal slot of _bound_ to _target_.
+- Return InitializeBoundFunctionProperties(_bound_, _target_).
+
+
+----
+
+    BindExpression :
+        LeftHandSideExpression :: [lookahead ≠ new] MemberExpression
+
+- Let _baseReference_ be the result of evaluating _LeftHandSideExpression_.
+- Let _baseValue_ be GetValue(_baseReference_).
+- Let _targetReference_ be the result of evaluating _MemberExpression_.
+- Let _target_ be GetValue(_targetReference_).
+- If IsCallable(_target_) is `false`, throw a `TypeError` exception.
+- Let _F_ be ? BoundFunctionCreate(_target_, _baseValue_, «»).
+- Return InitializeBoundFunctionProperties(_F_, _target_).
 
 
 ----
@@ -168,14 +226,4 @@ produce early errors because of recursive application of the first rule.
 - Let _target_ be GetValue(_targetReference_).
 - If IsCallable(_target_) is `false`, throw a `TypeError` exception.
 - Let _F_ be ? BoundFunctionCreate(_target_, _thisValue_, «»).
-- Let _targetHasLength_ be ? HasOwnProperty(_target_, `"length"`).
-- If _targetHasLength_ is **true**, then
-    - Let _targetLen_ be ? Get(_target_, `"length"`).
-    - If Type(_targetLen_) is not `Number`, then let _L_ be `0`.
-    - Else, let _L_ be ToInteger(_targetLen_).
-- Else let _L_ be `0`.
-- Let _status_ be ? DefinePropertyOrThrow(_F_, `"length"`, PropertyDescriptor {[[Value]]: _L_, [[Writable]]: `false`, [[Enumerable]]: `false`, [[Configurable]]: `true`}).
-- Let _targetName_ be ? Get(_target_, `"name"`).
-- If Type(_targetName_) is not `String`, then let _targetName_ be the empty string.
-- Let _status_ be ? SetFunctionName(_F_, _targetName_, `"bound"`).
-- Return _F_.
+- Return InitializeBoundFunctionProperties(_F_, _target_).


### PR DESCRIPTION
Brought up in passing in #26, but was never actually in the spec (feature more important than syntax).

I believe this works similarly to `::obj.foo`, but specifically calls the constructor, as in `::Class[new]`. It's unambiguously the constructor, and would fail in any other context.